### PR TITLE
Swap dist and port fields in axfr-get.c

### DIFF
--- a/axfr-get.c
+++ b/axfr-get.c
@@ -223,11 +223,11 @@ unsigned int doit(char *buf,unsigned int len,unsigned int pos)
     x_getname(buf,len,pos,&d1);
     if (!dns_domain_todot_cat(&line,d1)) return 0;
     if (!stralloc_cats(&line,".:")) return 0;
-    if (!stralloc_catulong0(&line,dist,0)) return 0;
+    if (!stralloc_catulong0(&line,port,0)) return 0;
     if (!stralloc_cats(&line,":")) return 0;
     if (!stralloc_catulong0(&line,weight,0)) return 0;
     if (!stralloc_cats(&line,":")) return 0;
-    if (!stralloc_catulong0(&line,port,0)) return 0;
+    if (!stralloc_catulong0(&line,dist,0)) return 0;
   }
   else if (byte_equal(data,2,DNS_T_NAPTR)) {
     uint16 order, preference;


### PR DESCRIPTION
The tinydns fields are in the reverse order to those presented in the SRV rdata.

Closes #1